### PR TITLE
ios change `joinOnce` type to `Bool`

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -137,7 +137,7 @@ public class Wifi: CAPPlugin {
             return
         }
         let password : String? = call.getString("password") ?? nil
-        let joinOnce : boolean = call.getBool("joinOnce") ?? false
+        let joinOnce : Bool = call.getBool("joinOnce") ?? false
 
         if #available(iOS 13, *) {
             var configuration : NEHotspotConfiguration

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -97,7 +97,7 @@ public class Wifi: CAPPlugin {
             return
         }
         let password : String? = call.getString("password") ?? nil
-        let joinOnce : boolean = call.getBool("joinOnce") ?? false
+        let joinOnce : Bool = call.getBool("joinOnce") ?? false
 
         if #available(iOS 11, *) {
             var configuration : NEHotspotConfiguration


### PR DESCRIPTION
Yesterday when I try to run on iOS (capacitor 3) I got this error `Cannot find type 'boolean' in scope`

![Screen Shot 2021-08-27 at 7 55 27 PM](https://user-images.githubusercontent.com/12681781/131201315-8d8ae269-1ec5-4da2-b101-7743ca9915f9.png)

